### PR TITLE
LCD-50578 Chart updates

### DIFF
--- a/cloud/helm/gcp/Chart.yaml
+++ b/cloud/helm/gcp/Chart.yaml
@@ -9,4 +9,4 @@ description:
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-gcp
 type: application
-version: 0.0.2
+version: 0.0.3

--- a/cloud/helm/gcp/templates/liferay-network-cm.yaml
+++ b/cloud/helm/gcp/templates/liferay-network-cm.yaml
@@ -1,11 +1,15 @@
+{{- $liferayDefault := index .Values "liferay-default" | default dict -}}
+{{- $network := $liferayDefault.network | default dict -}}
+{{- if and $network $network.enabled }}
 apiVersion: v1
 data:
-    {{- if and .Values.network .Values.network.enabled .Values.network.hostnames }}
-    LIFERAY_COMPANY_PERIOD_DEFAULT_PERIOD_VIRTUAL_PERIOD_HOST_PERIOD_NAME: {{ index .Values.network.hostnames 0 | quote }}
-    LIFERAY_COMPANY_PERIOD_DEFAULT_PERIOD_WEB_PERIOD_ID: {{ index .Values.network.hostnames 0 | quote }}
-    LIFERAY_VIRTUAL_PERIOD_HOSTS_PERIOD_VALID_PERIOD_HOSTS: {{ join "," .Values.network.hostnames | quote }}
+    {{- if $network.hostnames }}
+    LIFERAY_COMPANY_PERIOD_DEFAULT_PERIOD_VIRTUAL_PERIOD_HOST_PERIOD_NAME: {{ index $network.hostnames 0 | quote }}
+    LIFERAY_COMPANY_PERIOD_DEFAULT_PERIOD_WEB_PERIOD_ID: {{ index $network.hostnames 0 | quote }}
+    LIFERAY_VIRTUAL_PERIOD_HOSTS_PERIOD_VALID_PERIOD_HOSTS: {{ concat $network.hostnames (list "localhost" "${env.POD_IP}") | join "," | quote }}
     {{- end }}
 kind: ConfigMap
 metadata:
     name: liferay-network
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/cloud/helm/gcp/templates/overlay-storage.yaml
+++ b/cloud/helm/gcp/templates/overlay-storage.yaml
@@ -1,0 +1,38 @@
+{{- $liferayDefault := index .Values "liferay-default" | default dict -}}
+{{- $overlay := $liferayDefault.overlay | default dict -}}
+{{- if and $overlay $overlay.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+    name: {{ $overlay.bucketName }}
+spec:
+    accessModes:
+        -   ReadWriteMany
+    capacity:
+        storage: 10Gi
+    claimRef:
+        name: {{ $overlay.bucketName }}
+        namespace: {{ .Release.Namespace }}
+    csi:
+        driver: gcsfuse.csi.storage.gke.io
+        volumeAttributes:
+            bucketName: {{ $overlay.bucketName }}
+        volumeHandle: {{ $overlay.bucketName }}
+    mountOptions:
+        -   gid=1000
+        -   implicit-dirs
+        -   uid=1000
+    storageClassName: {{ $overlay.bucketName }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: {{ $overlay.bucketName }}
+spec:
+    accessModes:
+        -   ReadWriteMany
+    resources:
+        requests:
+            storage: 10Gi
+    storageClassName: {{ $overlay.bucketName }}
+{{- end }}

--- a/cloud/helm/gcp/values.yaml
+++ b/cloud/helm/gcp/values.yaml
@@ -93,7 +93,7 @@ liferay-default:
             backendRequest: 300s
             request: 300s
     overlay:
-        bucketName: $[env:LIFERAY_OVERLAY_BUCKET_NAME]
+        bucketName: ""
         driver: gcsfuse.csi.storage.gke.io
         enabled: false
     podAnnotations:

--- a/cloud/helm/gcp/values.yaml
+++ b/cloud/helm/gcp/values.yaml
@@ -1,6 +1,17 @@
 liferay-default:
+    annotations:
+        instrumentation.opentelemetry.io/inject-dotnet: "false"
+        instrumentation.opentelemetry.io/inject-java: "false"
+        instrumentation.opentelemetry.io/inject-nodejs: "false"
+        instrumentation.opentelemetry.io/inject-python: "false"
+        sidecar.opentelemetry.io/inject: "false"
     configmap:
         data:
+            com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config: |
+                authenticationEnabled=B"false"
+                httpSSLEnabled=B"false"
+                networkHostAddresses=["$[env:ELASTICSEARCH_URL]"]
+                productionModeEnabled=B"true"
             com.liferay.portal.store.gcs.configuration.GCSStoreConfiguration.config: |
                 bucketName="$[env:LIFERAY_GCS_BUCKET_NAME]"
     customEnv:
@@ -9,22 +20,84 @@ liferay-default:
                 value: "true"
             -   name: LIFERAY_DL_PERIOD_STORE_PERIOD_IMPL
                 value: com.liferay.portal.store.gcs.GCSStore
+            -   name: LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME
+                value: org.postgresql.Driver
+            -   name: LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL
+                value: jdbc:postgresql://localhost:${env.DATABASE_PORT}/lportal?useUnicode=true&characterEncoding=UTF-8&useFastDateParsing=false
+            -   name: LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME
+                value: ${env.DATABASE_USERNAME}
+            -   name: LIFERAY_WEB_PERIOD_SERVER_PERIOD_FORWARDED_PERIOD_PORT_PERIOD_ENABLED
+                value: "true"
+            -   name: LIFERAY_WEB_PERIOD_SERVER_PERIOD_FORWARDED_PERIOD_PROTOCOL_PERIOD_ENABLED
+                value: "true"
     customEnvFrom:
         x-liferay-gcp:
             -   configMapRef:
-                    name: liferay-company-domain-config
+                    name: liferay-network
+            -   secretRef:
+                    name: elasticsearch-connection-details
             -   secretRef:
                     name: managed-service-details
+    customInitContainers:
+        x-cloud-sql-auth-proxy-enabled:
+            -   args:
+                    -   "$(DATABASE_INSTANCE_NAME)"
+                    -   "--auto-iam-authn"
+                    -   "--port=$(DATABASE_PORT)"
+                    -   "--private-ip"
+                    -   "--structured-logs"
+                env:
+                    -   name: CSQL_PROXY_HEALTH_CHECK
+                        value: "true"
+                    -   name: CSQL_PROXY_HTTP_ADDRESS
+                        value: 0.0.0.0
+                    -   name: CSQL_PROXY_HTTP_PORT
+                        value: "9801"
+                envFrom:
+                    -   secretRef:
+                            name: managed-service-details
+                image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
+                name: cloud-sql-proxy
+                restartPolicy: Always
+                securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                        drop:
+                            -   ALL
+                    runAsNonRoot: true
+                    seccompProfile:
+                        type: RuntimeDefault
     customLabels:
         origin: liferay-gcp
     customVolumeMounts:
+        x-license:
+            -   mountPath: /etc/liferay/mount/files/deploy/license.xml
+                name: liferay-license
+                subPath: license.xml
         x-liferay-gcp:
+            -   mountPath: /opt/liferay/osgi/configs/com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config
+                name: liferay-configmap
+                subPath: com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config
             -   mountPath: /opt/liferay/osgi/configs/com.liferay.portal.store.gcs.configuration.GCSStoreConfiguration.config
                 name: liferay-configmap
                 subPath: com.liferay.portal.store.gcs.configuration.GCSStoreConfiguration.config
+    customVolumes:
+        x-license:
+            -   name: liferay-license
+                secret:
+                    secretName: liferay-license
     network:
         enabled: true
         hostnames: []
+        timeouts:
+            backendRequest: 300s
+            request: 300s
+    overlay:
+        bucketName: $[env:LIFERAY_OVERLAY_BUCKET_NAME]
+        driver: gcsfuse.csi.storage.gke.io
+        enabled: false
+    podAnnotations:
+        gke-gcsfuse/volumes: "true"
     podSecurityContext:
         fsGroup: 1000
         runAsNonRoot: true
@@ -35,8 +108,8 @@ liferay-default:
             cpu: 4000m
             memory: 12Gi
         requests:
-            cpu: 500m
-            memory: 1.5Gi
+            cpu: 2000m
+            memory: 4Gi
     securityContext:
         allowPrivilegeEscalation: false
         capabilities:
@@ -46,6 +119,18 @@ liferay-default:
         runAsUser: 1000
         seccompProfile:
             type: RuntimeDefault
+    startupProbe:
+        exec:
+            command:
+                -   /bin/sh
+                -   -c
+                -   |
+                        curl -f http://localhost:9801/startup && \
+                        curl -f http://localhost:8080/c/portal/robots
+        failureThreshold: 90
+        httpGet: null
+        periodSeconds: 10
+        timeoutSeconds: 5
     volumeClaimTemplates:
         -   metadata:
                 name: liferay-persistent-volume


### PR DESCRIPTION
- **LCD-50367 Add kustomize on 2nd source**
- **LCD-50367 Add defaults for elasticsearch**
- **LCD-50367 Must disable readonly filesystem to actually install plugins**
- **LCD-50367 Disable opentelemetry on ElasticSearch**
- **LPD-83005 check for OBJECT_ENTRY_HISTORY to return versions instead**
- **LPD-83005 add entry history permission to ASSET_LIBRARY_MEMBER**
- **LPD-83005 add coverage**
- **LPD-78839 Create a type to represent the loadData function parameters**
- **LPD-78839 Create an utility to transform additional API URL parameters**
- **LPD-78839 Enable a mechanism to inject a additionalAPIURLParametersTransformer callback in the FDS. This is not setting the internal state but hooks up before fetching data as a last-minute place to modify the parameters for each particular loadData call**
- **LPD-78839 Add unit tests**
- **LPD-78839 Rename, use type naming convention**
- **LCD-50503 Add argocd networking and application definitions**
- **LCD-50503 Update infrastructure chart to use new parameters**
- **LCD-50503 SF**
- **LCD-50578 Chart updates**
