### PR TITLE
LCD 50869

### DIFF
--- a/cloud/helm/gcp-infrastructure-provider/compositions/00-globals.gotmpl
+++ b/cloud/helm/gcp-infrastructure-provider/compositions/00-globals.gotmpl
@@ -4,15 +4,17 @@
 {{- $backup := $xr.spec.backup | default dict -}}
 {{- $cmkEnabled := $xr.spec.cmk.enabled | default false -}}
 {{- $commonTags := $xr.spec.commonTags | default dict -}}
-{{- $databaseInstanceName := printf "%s-db-instance" $xr.metadata.name -}}
+{{- $deploymentName := $env.deploymentName -}}
+{{- $prefixedName := printf "%s-%s" $deploymentName $xr.metadata.name -}}
+{{- $databaseInstanceName := printf "%s-db" $prefixedName -}}
 {{- $databaseName := $xr.spec.database.name | default "lportal" -}}
 {{- $databasePort := "5432" -}}
 {{- $databaseSpec := $xr.spec.database -}}
 {{- $deletionProtection := $xr.spec.deletionProtection | default false -}}
 {{- $environmentId := $xr.spec.environmentId -}}
 {{- $forceDestroy := $xr.spec.forceDestroy | default false -}}
-{{- $gsaName := printf "%s-sa" $xr.metadata.name -}}
-{{- $jobName := printf "%s-db-grant" $xr.metadata.name -}}
+{{- $gsaName := printf "%s-sa" $prefixedName -}}
+{{- $jobName := printf "%s-db-grant" $prefixedName -}}
 {{- $managementPoliciesOnce := (list "Create" "Observe" "Delete") | toJson -}}
 {{- $namespace := $xr.metadata.namespace -}}
 {{- $overlay := $xr.spec.overlay | default dict -}}
@@ -22,7 +24,7 @@
 {{- $databaseIamUser := printf "%s@%s.iam" $gsaName $env.projectId -}}
 {{- $gsaEmail := printf "%s@%s.iam.gserviceaccount.com" $gsaName $env.projectId -}}
 {{- $hash := printf "%s-%s" $databaseName $env.projectId | sha256sum | trunc 7 -}}
-{{- $labels := merge $commonTags (dict "app" "liferay" "environment-id" $environmentId "project-id" $projectId) -}}
+{{- $labels := merge $commonTags (dict "app" "liferay" "deployment-name" $deploymentName "environment-id" $environmentId "project-id" $projectId) -}}
 {{- $backupTargetLabels := merge (dict) $labels (dict "active" "true" "should-back-up" "true") -}}
 {{- $managementPolicies := $xr.spec.orphanOnDelete | ternary (list "Create" "Observe" "Update") (list "*") | toJson -}}
 {{- $managementPoliciesNoUpdate := $xr.spec.orphanOnDelete | ternary (list "Create" "Observe") (list "Create" "Delete" "Observe") | toJson -}}
@@ -30,7 +32,7 @@
 {{- $region := $databaseSpec.region | default "us-central1" -}}
 {{- $uidHash := printf "%s-%s" $env.projectNumber $projectIdFull | sha256sum | trunc 6 -}}
 
-{{- $baseName := printf "%.18s-%s" $projectIdFull $uidHash -}}
+{{- $baseName := printf "%.10s-%.10s-%s" $deploymentName $projectIdFull $uidHash -}}
 
 {{- $cmkKeyName := printf "projects/%s/locations/%s/keyRings/%s-keyring/cryptoKeys/%s-key" $env.projectId $region $baseName $baseName -}}
 {{- $instanceConnectionName := printf "%s:%s:%s" $env.projectId $region $databaseInstanceName -}}

--- a/cloud/helm/gcp-infrastructure-provider/compositions/10-iam.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/compositions/10-iam.yaml
@@ -17,9 +17,10 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-wi-binding
     labels:
         {{- $labels | toYaml | nindent 8 }}
+    name: {{ $prefixedName }}-wi-binding
 spec:
     forProvider:
-        member: serviceAccount:{{ $env.projectId }}.svc.id.goog[{{ $namespace }}/liferay-default]
+        member: principalSet://iam.googleapis.com/projects/{{ $env.projectNumber }}/locations/global/workloadIdentityPools/{{ $env.projectId }}.svc.id.goog/attribute.cluster_name/{{ $deploymentName }}-gke/ns/{{ $namespace }}/sa/liferay-default
         role: roles/iam.workloadIdentityUser
         serviceAccountIdRef:
             name: {{ $gsaName }}
@@ -31,6 +32,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-sql-instance-user-role
     labels:
         {{- $labels | toYaml | nindent 8 }}
+    name: {{ $prefixedName }}-sql-instance-user-role
 spec:
     forProvider:
         member: serviceAccount:{{ $gsaEmail }}
@@ -44,6 +46,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-sql-client-role
     labels:
         {{- $labels | toYaml | nindent 8 }}
+    name: {{ $prefixedName }}-sql-client-role
 spec:
     forProvider:
         member: serviceAccount:{{ $gsaEmail }}

--- a/cloud/helm/gcp-infrastructure-provider/compositions/20-sql.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/compositions/20-sql.yaml
@@ -43,7 +43,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-db
     labels:
         {{- $labels | toYaml | nindent 8 }}
-    name: {{ $xr.metadata.name }}-db
+    name: {{ $prefixedName }}-db
 spec:
     forProvider:
         charset: UTF8
@@ -60,7 +60,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-iam-user
     labels:
         {{- $labels | toYaml | nindent 8 }}
-    name: {{ $xr.metadata.name }}-db-user
+    name: {{ $prefixedName }}-db-user
 spec:
     forProvider:
         instanceSelector:
@@ -73,14 +73,14 @@ kind: Usage
 metadata:
     annotations:
         gotemplating.fn.crossplane.io/composition-resource-name: usage-instance-by-database
-    name: {{ $xr.metadata.name }}-instance-by-database
+    name: {{ $prefixedName }}-instance-by-database
     namespace: {{ $namespace }}
 spec:
     by:
         apiVersion: sql.gcp.m.upbound.io/v1beta1
         kind: Database
         resourceRef:
-            name: {{ $xr.metadata.name }}-db
+            name: {{ $prefixedName }}-db
     of:
         apiVersion: sql.gcp.m.upbound.io/v1beta1
         kind: DatabaseInstance
@@ -92,14 +92,14 @@ kind: Usage
 metadata:
     annotations:
         gotemplating.fn.crossplane.io/composition-resource-name: usage-instance-by-user
-    name: {{ $xr.metadata.name }}-instance-by-user
+    name: {{ $prefixedName }}-instance-by-user
     namespace: {{ $namespace }}
 spec:
     by:
         apiVersion: sql.gcp.m.upbound.io/v1beta1
         kind: User
         resourceRef:
-            name: {{ $xr.metadata.name }}-db-user
+            name: {{ $prefixedName }}-db-user
     of:
         apiVersion: sql.gcp.m.upbound.io/v1beta1
         kind: DatabaseInstance

--- a/cloud/helm/gcp-infrastructure-provider/compositions/30-k8s.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/compositions/30-k8s.yaml
@@ -5,7 +5,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-ksa
     labels:
         {{- $labels | toYaml | nindent 8 }}
-    name: {{ $xr.metadata.name }}-ksa
+    name: {{ $prefixedName }}-ksa
 spec:
     forProvider:
         manifest:

--- a/cloud/helm/gcp-infrastructure-provider/compositions/40-storage.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/compositions/40-storage.yaml
@@ -29,6 +29,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-gcs-iam
     labels:
         {{- $labels | toYaml | nindent 8 }}
+    name: {{ $prefixedName }}-gcs-iam
 spec:
     forProvider:
         bucketRef:

--- a/cloud/helm/gcp-infrastructure-provider/compositions/50-overlay.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/compositions/50-overlay.yaml
@@ -30,6 +30,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-gsa-overlay-bucket-iam
     labels:
         {{- $labels | toYaml | nindent 8 }}
+    name: {{ $prefixedName }}-overlay-bucket-iam
 spec:
     forProvider:
         bucketRef:

--- a/cloud/helm/gcp-infrastructure-provider/compositions/60-kms.yaml
+++ b/cloud/helm/gcp-infrastructure-provider/compositions/60-kms.yaml
@@ -35,6 +35,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-sql-kms-binding
     labels:
         {{- $labels | toYaml | nindent 8 }}
+    name: {{ $prefixedName }}-sql-kms-binding
 spec:
     forProvider:
         cryptoKeyIdRef:
@@ -50,6 +51,7 @@ metadata:
         gotemplating.fn.crossplane.io/composition-resource-name: liferay-storage-kms-binding
     labels:
         {{- $labels | toYaml | nindent 8 }}
+    name: {{ $prefixedName }}-storage-kms-binding
 spec:
     forProvider:
         cryptoKeyIdRef:

--- a/cloud/terraform/gcp/gitops/resources/crossplane.tf
+++ b/cloud/terraform/gcp/gitops/resources/crossplane.tf
@@ -15,7 +15,7 @@ resource "google_service_account" "cloudplatform_gsa" {
 	project=var.project_id
 }
 resource "google_service_account_iam_member" "cloudplatform_wi_binding" {
-	member="serviceAccount:${var.project_id}.svc.id.goog[${var.crossplane_namespace}/provider-gcp-cloudplatform]"
+	member="principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog/attribute.cluster_name/${var.deployment_name}-gke/ns/${var.crossplane_namespace}/sa/provider-gcp-cloudplatform"
 	role="roles/iam.workloadIdentityUser"
 	service_account_id=google_service_account.cloudplatform_gsa.name
 }

--- a/cloud/terraform/gcp/gitops/resources/locals.tf
+++ b/cloud/terraform/gcp/gitops/resources/locals.tf
@@ -70,7 +70,7 @@ locals {
 	git_repo_infrastructure_separate_from_liferay=local.infrastructure_git_repo_url != var.liferay_git_repo_url
 	infrastructure_appproject_name="liferay-infrastructure"
 	infrastructure_git_repo_url=coalesce(var.infrastructure_git_repo_config.url, var.liferay_git_repo_url)
-	ksa_principal_base="principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog/subject/ns/${var.crossplane_namespace}/sa"
+	ksa_principal_base="principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog/attribute.cluster_name/${var.deployment_name}-gke/ns/${var.crossplane_namespace}/sa"
 	liferay_appproject_name="liferay-application"
 	liferay_helm_chart_config=merge(
 		var.liferay_helm_chart_config,


### PR DESCRIPTION
- **LCD-50897 Add checkov exception for storage transfer service permissions**
- **LPS-77699 Update Translations**
- **LPS-77699 Update Translations**
- **LPD-85911 ClassLoader bridge RPC results.**
- **LPD-85911 SF**
- **LPD-84163 feat: add crawl standalone object action to AIHubContentRetriever object definition**
- **LPD-84163 feat: add dropdown action that performs the crawl request**
- **LPD-84163 generated: gw buildLang**
- **LPD-85844 Add new AI Hub Provisioning endpoint**
- **LPD-85844 buildRest**
- **LPD-85844 Implement ProvisioningRequestResourceImpl**
- **LPD-85844 Impersonate account entry service account when a guest is invoking an agent in a chatbot context**
- **LPD-85844 Add integration test**
- **LCD-50907 Update CRDs with new resolved fields**
- **LPD-3057 Add data validation for Max Users field when creating Virtual Instance**
- **LPD-3057 Add validateMaxUsers test to CompanyLocalServiceTest**
- **LPD-3057 Modified test method name for max users validation**
- **LPD-3057 Unify test names**
- **LPD-3057 Test methods collapsed in testUpdateCompany**
- **LPD-3057 buildLang**
- **LPD-3057 Rename valid expectedFailure to _testUpdateCompanyNames to align with existing method**
- **LPD-3057 SF**
- **LPD-85865 Create new method to check if predefined value is empty**
- **LPD-85865 Apply to use new method**
- **LPD-85865 Add unit test**
- **LCD-50892 Use correct annotations field**
- **LPD-85968 Remove dark mode**
- **LPD-83363 Update google-cloud-translate version**
- **LPD-81938 SF**
- **LPD-85596 change to use ant build-services for service builder on ci**
- **LPD-85596 combine service builder into one report in jenkins**
- **LPD-85596 remove skip.service.builder check as it is not needed**
- **LPD-84494 adapt to frontend dataset pattern**
- **LPD-83266 Check a users permissions on the entry to see if they have elevated permissions from a role on the space**
- **LPD-83266 Update existing tests to give elevated users the correct permissions on SharedAssets.**
- **LPD-83266 SF**
- **LPD-78887 Group files in nonconflicting upload batches To prevent conflicts when generating friendly urls in the backend, upload files in groups that are guaranteed to be conflict-free.  All files in each group are uploaded in parallel, but different groups are uploaded in sequence.**
- **LPD-78887 SF - Identation**
- **LPD-78887 Unit test**
- **LPD-78887 Fix failing unit tests**
- **LPD-78887 unskip test, is passing successfully**
- **LPD-78887 compare between numbers. It was failing when we have only one space**
- **LCD-50911 Update CRDs**
- **LPD-69639 fix: Add writing assistant balloon action group component**
- **LPD-69639 fix: Add action group type**
- **LPD-69639 fix: add writing assistant ballon component**
- **LPD-69639 fix: add confimation balloon**
- **LPD-69639 fix: replace dropdown with custom writing assistant balloon component**
- **LPD-69639 fix: replace dropdown with Confirmation balloon component**
- **LPD-69639 fix: styles**
- **LPD-69639 fix: move balloon close logic into their own components**
- **LPD-69639 refactor: remove writing assistant plugin components from frontend-editor-ckeditor-web**
- **LPD-69639 refactor: create ai hub cell js components web**
- **LPD-69639 refactor: move writing assistant components to ai hub cell js components web**
- **LPD-69639 refactor: add ai-hub-cell-js-components-web dependency**
- **LPD-69639 generated: yarn node-scripts generate:tsconfig**
- **LPD-69639 refactor: import writing assistant from ai-hub-cell-js-components-web**
- **LPD-69639 refactor: remove unnecessary style**
- **LPD-69639 generated: node-scripts.config.js**
- **LPD-86007 Add ant build-rests target for bulk REST Builder invocation**
- **LPD-86007 Add continue to build-services' baseline too.**
- **LPD-86007 Regenerate**
- **LPD-86007 SF**
- **LPD-86007 prep next**
- **LPD-86007 prep next**
- **LPD-84138 Add integration tests to check permissions for ListTypeDefinition CRUD operations**
- **LPD-84208 Add integration tests to check permissions for ObjectDefinition CRUD operations**
- **LPD-84234 Add integration tests to check permissions for ObjectEntry CRUD operations**
- **LPD-84324 Move Poshi tests to playwright**
- **LPD-82346 Remove Poshi tests**
- **LPD-79484 Remove Templates from DSR Management**
- **LPD-79484 Fix onboarding page**
- **LPD-83812 Adds permission to Order Administrator role**
- **LPD-83812 Adds upgradeProcess**
- **LPD-83812 Adds integration tests**
- **LPD-79484 Fire event on comment add**
- **LPD-79484 Unit test**
- **LPD-79484 Fire event on file upload**
- **LPD-79484 Unit test**
- **LPD-79484 Update template**
- **LPD-79484 Move to component**
- **LPD-86007 Change ServiceBuilder and RESTBuilder to communicate the baselien task list via output files.**
- **LPD-86007 Switch back to use System.out for expected "logging" outputs.**
- **LPD-86007 Regenerate**
- **LPD-86007 prep next**
- **LPD-86007 prep next**
- **LPD-86010 Use correct class name for FriendlyURLAuthVerifierFilter**
- **LPD-85998 Fix failing js unit tests**
- **LPD-76355 Add action to add category in vocabulary FDS**
- **LCD-50869 Use principalSet syntax to target our k8s cluster specifically**
- **LCD-50869 Add deployment name to names and labels**
